### PR TITLE
Change hostname to certname for EC2

### DIFF
--- a/tasks/run.sh
+++ b/tasks/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if puppet config print server | grep -v -q `hostname`; then
+if puppet config print server | grep -v -q `puppet config print certname`; then
   echo "This task can only be run on the master node."; 
   exit 1
 fi


### PR DESCRIPTION
I couldn't use this task out of the box on my OpsWorks PE Master.

Here's the result I got for a query of `facts {}` in the PE console GUI:

```
query: facts {}
Results (YAML):

Query results (YAML) can be found here: /tmp/pqlquery_1517376954.yaml
Query results (JSON) can be found here: /tmp/pqlquery_1517376954.json
```

I didn't even get the error message, which you probably get on the CLI, I'm guessing.

Here's why this was happening (run on the master):

```
# puppet config print certname
foo-master-abcdefghijk.us-west-2.opsworks-cm.io
# puppet config print server
foo-master-abcdefghijk.us-west-2.opsworks-cm.io
# hostname
ip-123-123-123-123
```